### PR TITLE
Fix iOS admin log initial bounds

### DIFF
--- a/internal/app/channels/service.go
+++ b/internal/app/channels/service.go
@@ -743,6 +743,9 @@ func (s *Service) ListAdminLog(ctx context.Context, userID int64, req domain.Cha
 	if req.UserID == 0 {
 		req.UserID = userID
 	}
+	if req.MinID < 0 {
+		req.MinID = 0
+	}
 	if req.UserID != userID || req.ChannelID == 0 || req.MaxID < 0 || req.MinID < 0 {
 		return domain.ChannelAdminLogResult{}, domain.ErrChannelInvalid
 	}

--- a/internal/app/channels/service_test.go
+++ b/internal/app/channels/service_test.go
@@ -2128,6 +2128,18 @@ func TestChannelAdminTitlePinAndInvite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAdminLog: %v", err)
 	}
+	iosInitialLogs, err := service.ListAdminLog(ctx, 1001, domain.ChannelAdminLogRequest{
+		ChannelID: created.Channel.ID,
+		MaxID:     1<<63 - 1,
+		MinID:     -1 << 63,
+		Limit:     20,
+	})
+	if err != nil {
+		t.Fatalf("ListAdminLog iOS initial bounds: %v", err)
+	}
+	if len(iosInitialLogs.Events) == 0 {
+		t.Fatalf("ListAdminLog iOS initial bounds returned no events, want admin history")
+	}
 	seen := map[domain.ChannelAdminLogEventType]bool{}
 	for _, event := range logs.Events {
 		seen[event.Type] = true


### PR DESCRIPTION
## Summary

Fixes the iOS Recent Actions admin log request path by accepting the official client's initial lower-bound value.

## Root Cause

Official Telegram iOS initializes `channels.getAdminLog` with `min_id = Int64.min` to represent an unbounded lower range. The server previously treated any negative `MinID` as invalid and returned `CHANNEL_INVALID`, which caused the iOS Recent Actions screen to keep spinning.

## Changes

- Normalize negative admin-log `MinID` values to `0` before request validation.
- Add a regression test covering the official iOS initial bounds: `MaxID = Int64.max`, `MinID = Int64.min`.

## Validation

- `go test ./internal/app/channels -run 'TestChannelAdminTitlePinAndInvite' -count=1`