### PR TITLE
fix: stabilize anonymous gift upgrades and MTProto service recovery

### DIFF
--- a/internal/mtprotoedge/encrypted.go
+++ b/internal/mtprotoedge/encrypted.go
@@ -1365,7 +1365,12 @@ func (s *Server) completeRPCResult(c *Conn, reqMsgID int64, encoded *encodedOutb
 
 // sendPong 回复 mt.PingRequest / mt.PingDelayDisconnectRequest。
 func (s *Server) sendPong(ctx context.Context, c *Conn, reqMsgID, pingID int64) error {
-	return c.SendAsync(ctx, proto.MessageServerResponse, &mt.Pong{MsgID: reqMsgID, PingID: pingID})
+	// Telegram iOS keeps the account in its connection-context "updating" state
+	// until the initial actualization ping receives its matching pong. A pong is
+	// therefore a request-correlated transport barrier, not disposable keepalive
+	// noise: if it cannot be written, reconnect instead of silently stranding the
+	// client on an otherwise healthy session.
+	return c.SendRequiredControl(ctx, proto.MessageServerResponse, &mt.Pong{MsgID: reqMsgID, PingID: pingID})
 }
 
 // sendFutureSalts 回复 MTProto get_future_salts。
@@ -1388,7 +1393,10 @@ func (s *Server) sendFutureSalts(ctx context.Context, c *Conn, reqMsgID int64, n
 			Salt:       c.salt,
 		})
 	}
-	return c.SendAsync(ctx, proto.MessageServerResponse, &mt.FutureSalts{
+	// future_salts completes the client's time/salt synchronization task. If it
+	// cannot be written, fail the connection so the client reconnects instead of
+	// remaining connected in a permanent service-task state.
+	return c.SendRequiredControl(ctx, proto.MessageServerResponse, &mt.FutureSalts{
 		ReqMsgID: reqMsgID,
 		Now:      now,
 		Salts:    salts,
@@ -1401,7 +1409,7 @@ func (s *Server) sendFutureSalts(ctx context.Context, c *Conn, reqMsgID int64, n
 // （Android 收到后才调 getDifference）随之丢失。
 func (s *Server) sendNewSessionCreated(ctx context.Context, c *Conn, firstMsgID int64) error {
 	// This notification changes the client's request map and update recovery
-	// state. Unlike best-effort ack/pong traffic, it must be written successfully
+	// state. Unlike best-effort ack traffic, it must be written successfully
 	// before the corresponding RPC batch starts executing.
 	return c.SendRequiredControl(ctx, proto.MessageFromServer, &mt.NewSessionCreated{
 		FirstMsgID: firstMsgID,
@@ -1425,7 +1433,9 @@ func (s *Server) sendAck(ctx context.Context, c *Conn, ids ...int64) error {
 
 // sendMsgsStateInfo 回复 msgs_state_req/msg_resend_req。
 func (s *Server) sendMsgsStateInfo(ctx context.Context, c *Conn, reqMsgID int64, info []byte) error {
-	return c.SendAsync(ctx, proto.MessageServerResponse, &mt.MsgsStateInfo{ReqMsgID: reqMsgID, Info: info})
+	// msgs_state_info terminates the client's resend service. Do not acknowledge
+	// the request locally and then silently discard its answer from a full queue.
+	return c.SendRequiredControl(ctx, proto.MessageServerResponse, &mt.MsgsStateInfo{ReqMsgID: reqMsgID, Info: info})
 }
 
 func (s *Server) sendDestroySession(ctx context.Context, c *Conn, sessionID int64) error {

--- a/internal/mtprotoedge/outbound.go
+++ b/internal/mtprotoedge/outbound.go
@@ -1491,10 +1491,11 @@ func (c *Conn) sendOutboundWithTerminalReserved(
 	}
 }
 
-// SendAsync 入队一条 server 消息但不等待发送结果（fire-and-forget），用于读循环里的控制消息
-// （ack/pong/bad_msg/future_salts/state_info）：避免读循环被 outbound 写
-// 阻塞而连带卡死。走优先(control)队列保证不被普通 push 拖后；队列满时丢弃并记 metrics——此时
-// 连接多已严重拥塞，控制消息丢失由客户端重传 / 读写超时兜底。返回非 nil 仅表示连接已关闭。
+// SendAsync enqueues a fire-and-forget server message without waiting for the
+// physical write. It is reserved for genuinely retryable/advisory control
+// traffic such as msgs_ack: a full control queue drops the message and records
+// a metric. Request-correlated service responses and protocol corrections must
+// use SendRequiredControl so they can never be reported as sent after a drop.
 func (c *Conn) SendAsync(ctx context.Context, t proto.MessageType, msg bin.Encoder) error {
 	if c.outbound == nil || c.outboundControl == nil {
 		return ErrConnClosed

--- a/internal/mtprotoedge/outbound_required_control_test.go
+++ b/internal/mtprotoedge/outbound_required_control_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/iamxvbaba/td/bin"
+	"github.com/iamxvbaba/td/clock"
 	"github.com/iamxvbaba/td/crypto"
 	"github.com/iamxvbaba/td/mt"
 	"github.com/iamxvbaba/td/proto"
@@ -54,6 +55,75 @@ func (t *gatedRequiredControlTransport) Close() error {
 
 func (t *gatedRequiredControlTransport) unblock() {
 	t.closeOnce.Do(func() { close(t.release) })
+}
+
+func TestServiceTaskResponsesWaitForPhysicalWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		send func(*Server, context.Context, *Conn) error
+	}{
+		{
+			name: "pong",
+			send: func(s *Server, ctx context.Context, c *Conn) error {
+				return s.sendPong(ctx, c, 11, 22)
+			},
+		},
+		{
+			name: "future_salts",
+			send: func(s *Server, ctx context.Context, c *Conn) error {
+				return s.sendFutureSalts(ctx, c, 11, 32)
+			},
+		},
+		{
+			name: "msgs_state_info",
+			send: func(s *Server, ctx context.Context, c *Conn) error {
+				return s.sendMsgsStateInfo(ctx, c, 11, []byte{4})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := newGatedRequiredControlTransport(nil)
+			c := newOutboundTestConn(t, tr, newOutboundTrackedBudget(1<<20))
+			c.outboundControlTrackedBudget = newOutboundTrackedBudget(1 << 20)
+			srv := &Server{clock: clock.System}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			done := make(chan error, 1)
+			go func() {
+				done <- tc.send(srv, ctx, c)
+			}()
+
+			select {
+			case <-tr.started:
+			case <-time.After(time.Second):
+				t.Fatal("service response did not reach the physical writer")
+			}
+			select {
+			case err := <-done:
+				t.Fatalf("service response returned before physical write completed: %v", err)
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			tr.unblock()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("service response: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("service response did not return after physical write")
+			}
+			if c.isRetired() {
+				t.Fatal("successful service response terminally closed the connection")
+			}
+			if got := tr.sends.Load(); got != 1 {
+				t.Fatalf("physical sends = %d, want 1", got)
+			}
+		})
+	}
 }
 
 func TestSendRequiredControlWaitsForPhysicalWriteAndReturnsBudget(t *testing.T) {

--- a/internal/rpc/payments_star_gifts.go
+++ b/internal/rpc/payments_star_gifts.go
@@ -1433,7 +1433,7 @@ func (r *Router) tgSavedStarGiftsResponse(ctx context.Context, viewerUserID int6
 		Gifts: projected,
 		Chats: []tg.ChatClass{},
 	}
-	if ids := savedStarGiftUserIDs(gifts); len(ids) > 0 {
+	if ids := savedStarGiftUserIDs(viewerUserID, gifts); len(ids) > 0 {
 		out.Users = tgUsersForViewer(viewerUserID, r.domainUsersForIDs(ctx, viewerUserID, ids))
 	} else {
 		out.Users = []tg.UserClass{}
@@ -1676,7 +1676,7 @@ func tgSavedStarGifts(viewerUserID int64, gifts []domain.SavedStarGift, catalog 
 		if g.Unsaved {
 			item.Unsaved = true
 		}
-		if g.FromUserID != 0 && !g.NameHidden {
+		if g.FromUserID != 0 && savedStarGiftOriginalDetailsVisible(viewerUserID, g) {
 			item.SetFromID(&tg.PeerUser{UserID: g.FromUserID})
 		}
 		if g.Owner.Type == domain.PeerTypeUser && g.MsgID > 0 {
@@ -1688,7 +1688,7 @@ func tgSavedStarGifts(viewerUserID int64, gifts []domain.SavedStarGift, catalog 
 		if g.ConvertStars > 0 {
 			item.SetConvertStars(g.ConvertStars)
 		}
-		if g.Message != "" {
+		if g.Message != "" && savedStarGiftOriginalDetailsVisible(viewerUserID, g) {
 			item.SetMessage(tg.TextWithEntities{Text: g.Message})
 		}
 		if g.UniqueGiftID == 0 {
@@ -1770,11 +1770,18 @@ func tgSavedStarGiftGift(g domain.SavedStarGift, catalog map[int64]domain.StarGi
 	}
 }
 
-func savedStarGiftUserIDs(gifts []domain.SavedStarGift) []int64 {
+func savedStarGiftOriginalDetailsVisible(viewerUserID int64, gift domain.SavedStarGift) bool {
+	if !gift.NameHidden {
+		return true
+	}
+	return gift.Owner.Type == domain.PeerTypeUser && gift.Owner.ID == viewerUserID
+}
+
+func savedStarGiftUserIDs(viewerUserID int64, gifts []domain.SavedStarGift) []int64 {
 	seen := make(map[int64]struct{}, len(gifts))
 	ids := make([]int64, 0, len(gifts))
 	for _, g := range gifts {
-		if g.FromUserID == 0 || g.NameHidden {
+		if g.FromUserID == 0 || !savedStarGiftOriginalDetailsVisible(viewerUserID, g) {
 			continue
 		}
 		if _, ok := seen[g.FromUserID]; ok {

--- a/internal/rpc/payments_star_gifts_rpc_test.go
+++ b/internal/rpc/payments_star_gifts_rpc_test.go
@@ -1346,8 +1346,9 @@ func TestStarGiftSaga(t *testing.T) {
 	}
 
 	inv := &tg.InputInvoiceStarGift{
-		Peer:   &tg.InputPeerUser{UserID: recipient.ID, AccessHash: recipient.AccessHash},
-		GiftID: gift.ID,
+		HideName: true,
+		Peer:     &tg.InputPeerUser{UserID: recipient.ID, AccessHash: recipient.AccessHash},
+		GiftID:   gift.ID,
 	}
 
 	// 2. getPaymentForm → paymentFormStarGift（XTR + 非空 prices）。
@@ -1418,6 +1419,19 @@ func TestStarGiftSaga(t *testing.T) {
 	}
 	if from, ok := saved.GetFromID(); !ok {
 		t.Fatalf("saved gift from = %v, want sender peer", from)
+	}
+	if !saved.NameHidden {
+		t.Fatal("saved gift name_hidden = false, want anonymous gift")
+	}
+	foundSender := false
+	for _, user := range savedRes.Users {
+		if got, ok := user.(*tg.User); ok && got.ID == sender.ID {
+			foundSender = true
+			break
+		}
+	}
+	if !foundSender {
+		t.Fatalf("saved gift users = %+v, want anonymous sender %d for receiver", savedRes.Users, sender.ID)
 	}
 
 	// 4b. 收礼人 userFull 必须带 stargifts_count（否则客户端资料页 Gifts 区段不出现）。
@@ -1971,5 +1985,60 @@ func TestStarsTopupRejectsUnlistedAmount(t *testing.T) {
 	_, err := r.onPaymentsGetPaymentForm(ctx, &tg.PaymentsGetPaymentFormRequest{Invoice: inv})
 	if !tgerr.Is(err, "STARS_FORM_AMOUNT_MISMATCH") {
 		t.Fatalf("getPaymentForm unlisted err = %v, want STARS_FORM_AMOUNT_MISMATCH", err)
+	}
+}
+
+func TestSavedStarGiftAnonymousDetailsVisibleOnlyToReceiver(t *testing.T) {
+	const (
+		senderID   = int64(1780243201)
+		receiverID = int64(1780243231)
+		viewerID   = int64(1780243999)
+	)
+	gift := domain.SavedStarGift{
+		Owner:      domain.Peer{Type: domain.PeerTypeUser, ID: receiverID},
+		FromUserID: senderID,
+		GiftID:     7001,
+		RevisionID: 8001,
+		MsgID:      91,
+		Date:       1700000000,
+		NameHidden: true,
+		Message:    "private gift message",
+	}
+
+	// Telegram iOS needs the sender peer to turn a user gift's msg_id into an
+	// InputSavedStarGiftUser reference. The protocol exposes hidden original
+	// details to the receiver, while keeping them hidden from profile viewers.
+	receiverProjection := tgSavedStarGifts(receiverID, []domain.SavedStarGift{gift}, nil, nil)
+	if len(receiverProjection) != 1 {
+		t.Fatalf("receiver projection len = %d, want 1", len(receiverProjection))
+	}
+	from, ok := receiverProjection[0].GetFromID()
+	fromUser, isUser := from.(*tg.PeerUser)
+	if !ok || !isUser || fromUser.UserID != senderID {
+		t.Fatalf("receiver from_id = %#v ok=%v, want sender %d", from, ok, senderID)
+	}
+	message, ok := receiverProjection[0].GetMessage()
+	if !ok || message.Text != gift.Message {
+		t.Fatalf("receiver message = %#v ok=%v, want private message", message, ok)
+	}
+	if msgID, ok := receiverProjection[0].GetMsgID(); !ok || msgID != gift.MsgID {
+		t.Fatalf("receiver msg_id = %d ok=%v, want %d", msgID, ok, gift.MsgID)
+	}
+	if ids := savedStarGiftUserIDs(receiverID, []domain.SavedStarGift{gift}); !reflect.DeepEqual(ids, []int64{senderID}) {
+		t.Fatalf("receiver user ids = %v, want sender %d", ids, senderID)
+	}
+
+	viewerProjection := tgSavedStarGifts(viewerID, []domain.SavedStarGift{gift}, nil, nil)
+	if len(viewerProjection) != 1 {
+		t.Fatalf("viewer projection len = %d, want 1", len(viewerProjection))
+	}
+	if from, ok := viewerProjection[0].GetFromID(); ok {
+		t.Fatalf("anonymous sender leaked to profile viewer: %#v", from)
+	}
+	if message, ok := viewerProjection[0].GetMessage(); ok {
+		t.Fatalf("anonymous message leaked to profile viewer: %#v", message)
+	}
+	if ids := savedStarGiftUserIDs(viewerID, []domain.SavedStarGift{gift}); len(ids) != 0 {
+		t.Fatalf("anonymous sender user leaked to profile viewer: %v", ids)
 	}
 }


### PR DESCRIPTION
## Summary

This PR contains two focused post-merge stability fixes:

- fixes anonymous Star Gift upgrades on iOS while preserving sender privacy for third-party profile viewers;
- prevents Telegram clients from remaining indefinitely in the **Updating...** state when a request-correlated MTProto service response cannot be delivered;
- requires no client-side changes and applies to iOS, Android, Telegram Desktop, and other MTProto-compatible clients.

## Problems and root causes

### 1. Anonymous Star Gift upgrade fails on iOS

For gifts purchased with **Hide name**, the saved-gift projection removed **from_id** and the sender user from every response, including responses viewed by the gift receiver.

Telegram iOS needs the sender peer together with **msg_id** to construct the user-gift reference used by the upgrade flow. Without that peer, the client cannot build the correct **InputSavedStarGiftUser** reference and displays a generic retry-later error.

The projection now exposes the original sender and gift message only when the viewer is the current gift owner. The same data remains hidden from all other profile viewers, so anonymous gift privacy is preserved.

### 2. Clients can remain stuck in Updating...

The MTProto edge previously sent **pong**, **future_salts**, and **msgs_state_info** through **SendAsync**. That path intentionally drops a control frame when the bounded control queue is full and returns success after recording a metric.

That behavior is acceptable for retryable advisory traffic such as **msgs_ack**, but not for request-correlated service responses:

- iOS keeps its connection-context update flag set until the initial actualization ping receives the matching pong;
- time and salt synchronization waits for future_salts;
- resend recovery waits for msgs_state_info.

If one of these replies was dropped while the connection remained alive, the client could stay in a permanent service state. Re-authentication appeared to fix the issue only because it replaced the affected session.

These replies now use **SendRequiredControl**. The operation waits for bounded queue admission and the physical socket write. If delivery cannot complete within the existing deadline, the connection is terminated so the client automatically reconnects instead of remaining half-alive.

## Changes

- expose hidden gift origin details to the gift receiver only;
- include the sender user in the receiver projection used by iOS gift upgrades;
- keep sender and message hidden from unrelated profile viewers;
- route pong through guaranteed control delivery;
- route future_salts through guaranteed control delivery;
- route msgs_state_info through guaranteed control delivery;
- document that SendAsync is reserved for genuinely retryable or advisory control traffic;
- add regression coverage for privacy boundaries and physical service-response delivery.

## Cross-client impact

This is a server-side MTProto correction. No client rebuild is needed.

All clients benefit from the recovery behavior, including:

- Telegram iOS;
- Telegram Android / APK builds;
- Telegram Desktop;
- other compatible MTProto clients.

## Safety and backpressure behavior

- Required control delivery remains bounded by the existing parent/write deadline and the five-second maximum operation budget.
- A failed critical service write closes only the affected connection and lets the client reconnect normally.
- Best-effort ACK behavior remains unchanged.
- Catch-up and FLOOD_WAIT rate limiting is unchanged.
- Anonymous sender information remains unavailable to third-party viewers.

## Verification

- go test ./internal/mtprotoedge -count=1
- go test ./internal/rpc -run TestCheckCatchupRateLimit -count=1
- go test ./... -count=1

The full repository test suite passes.

New regression coverage verifies:

- anonymous sender details are visible to the receiver but not leaked to other viewers;
- pong, future_salts, and msgs_state_info do not report success before their physical writes complete;
- successful required service responses do not retire a healthy connection.
