### PR TITLE
giftfetch: handle net errors and support socks5 proxy

### DIFF
--- a/cmd/giftfetch/main.go
+++ b/cmd/giftfetch/main.go
@@ -17,7 +17,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-    "net"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -28,11 +29,11 @@ import (
 
 	"github.com/iamxvbaba/td/bin"
 	"github.com/iamxvbaba/td/telegram"
+	"github.com/iamxvbaba/td/telegram/dcs"
 	"github.com/iamxvbaba/td/telegram/downloader"
-    "github.com/iamxvbaba/td/telegram/dcs"
 	"github.com/iamxvbaba/td/tg"
+	"golang.org/x/net/proxy"
 	"golang.org/x/sync/errgroup"
-    "golang.org/x/net/proxy"
 
 	"telesrv/internal/app/stargifts"
 )
@@ -68,6 +69,11 @@ type catalogManifest struct {
 	Documents                []documentManifest            `json:"documents"`
 	TotalBytes               int64                         `json:"total_document_bytes"`
 	BoundaryNote             string                        `json:"boundary_note"`
+}
+
+type socks5ProxyConfig struct {
+	Address string
+	Auth    *proxy.Auth
 }
 
 type giftManifest struct {
@@ -227,7 +233,12 @@ func main() {
 		SessionStorage: &telegram.FileSessionStorage{Path: session},
 	}
 	if socksProxy := strings.TrimSpace(os.Getenv("SOCKS5_PROXY")); socksProxy != "" {
-		dialer, err := proxy.SOCKS5("tcp", socksProxy, nil, proxy.Direct)
+		proxyConfig, err := parseSOCKS5Proxy(socksProxy)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: invalid SOCKS5_PROXY: %v\n", err)
+			os.Exit(2)
+		}
+		dialer, err := proxy.SOCKS5("tcp", proxyConfig.Address, proxyConfig.Auth, proxy.Direct)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: invalid SOCKS5_PROXY: %v\n", err)
 			os.Exit(2)
@@ -255,6 +266,54 @@ func main() {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
 		os.Exit(1)
 	}
+}
+
+func parseSOCKS5Proxy(raw string) (socks5ProxyConfig, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return socks5ProxyConfig{}, errors.New("must not be empty")
+	}
+	if strings.Contains(raw, "://") {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return socks5ProxyConfig{}, err
+		}
+		if parsed.Scheme != "socks5" {
+			return socks5ProxyConfig{}, fmt.Errorf("scheme must be socks5, got %q", parsed.Scheme)
+		}
+		if parsed.Host == "" {
+			return socks5ProxyConfig{}, errors.New("missing proxy host")
+		}
+		if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return socks5ProxyConfig{}, errors.New("must not include path, query, or fragment")
+		}
+		address, err := normalizeProxyAddress(parsed.Host)
+		if err != nil {
+			return socks5ProxyConfig{}, err
+		}
+		var auth *proxy.Auth
+		if parsed.User != nil {
+			password, _ := parsed.User.Password()
+			auth = &proxy.Auth{User: parsed.User.Username(), Password: password}
+		}
+		return socks5ProxyConfig{Address: address, Auth: auth}, nil
+	}
+	address, err := normalizeProxyAddress(raw)
+	if err != nil {
+		return socks5ProxyConfig{}, err
+	}
+	return socks5ProxyConfig{Address: address}, nil
+}
+
+func normalizeProxyAddress(raw string) (string, error) {
+	host, port, err := net.SplitHostPort(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("must be host:port or socks5://host:port: %w", err)
+	}
+	if strings.TrimSpace(host) == "" || strings.TrimSpace(port) == "" {
+		return "", errors.New("host and port are required")
+	}
+	return net.JoinHostPort(host, port), nil
 }
 
 func fetchCatalog(ctx context.Context, api *tg.Client, outDir string, maxDocBytes int64, skipThumbs bool, workers int, reuseMetadata bool, allowedMissingThumbs map[string]struct{}) error {
@@ -633,8 +692,8 @@ func fetchDocument(ctx context.Context, api *tg.Client, dl *downloader.Downloade
 	if !reused {
 		fmt.Printf("[network fetch] document=%d resource=document expected_size=%d part_size=%d\n", doc.ID, doc.Size, downloadPartSize(doc.Size))
 		data, err = retryOnTimeout(ctx, fmt.Sprintf("document %d", doc.ID), func() ([]byte, error) {
-            return download(ctx, api, dl, doc, "", doc.Size, maxBytes)
-        })
+			return download(ctx, api, dl, doc, "", doc.Size, maxBytes)
+		})
 		if err != nil {
 			return documentManifest{}, fmt.Errorf("download document %d: %w", doc.ID, err)
 		}
@@ -719,8 +778,8 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 				downloadAttempted = true
 				fmt.Printf("[network fetch] document=%d resource=photo-thumb type=%s expected_size=%d part_size=%d\n", doc.ID, thumbType, expectedSize, downloadPartSize(expectedSize))
 				data, err = retryOnTimeout(ctx, fmt.Sprintf("photo-thumb %d (%s)", doc.ID, thumbType), func() ([]byte, error) {
-                    return download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
-                })
+					return download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
+				})
 			}
 		case *tg.PhotoSizeProgressive:
 			if len(value.Sizes) == 0 {
@@ -737,8 +796,8 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 				downloadAttempted = true
 				fmt.Printf("[network fetch] document=%d resource=photo-thumb-progressive type=%s expected_size=%d part_size=%d\n", doc.ID, thumbType, expectedSize, downloadPartSize(expectedSize))
 				data, err = retryOnTimeout(ctx, fmt.Sprintf("progressive-thumb %d (%s)", doc.ID, thumbType), func() ([]byte, error) {
-                    return download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
-                })
+					return download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
+				})
 			}
 		default:
 			continue
@@ -781,8 +840,8 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 			downloadAttempted = true
 			fmt.Printf("[network fetch] document=%d resource=video-thumb type=%s expected_size=%d part_size=%d\n", doc.ID, value.Type, value.Size, downloadPartSize(int64(value.Size)))
 			data, err = retryOnTimeout(ctx, fmt.Sprintf("video-thumb %d (%s)", doc.ID, value.Type), func() ([]byte, error) {
-                return download(ctx, api, dl, doc, value.Type, int64(value.Size), maxBytes)
-            })
+				return download(ctx, api, dl, doc, value.Type, int64(value.Size), maxBytes)
+			})
 		}
 		if err != nil {
 			if downloadAttempted && missingThumbAllowed(allowedMissingThumbs, doc.ID, "video", value.Type) {

--- a/cmd/giftfetch/main.go
+++ b/cmd/giftfetch/main.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+    "net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -28,8 +29,10 @@ import (
 	"github.com/iamxvbaba/td/bin"
 	"github.com/iamxvbaba/td/telegram"
 	"github.com/iamxvbaba/td/telegram/downloader"
+    "github.com/iamxvbaba/td/telegram/dcs"
 	"github.com/iamxvbaba/td/tg"
 	"golang.org/x/sync/errgroup"
+    "golang.org/x/net/proxy"
 
 	"telesrv/internal/app/stargifts"
 )
@@ -219,9 +222,25 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Hour)
 	defer cancel()
-	client := telegram.NewClient(apiID, apiHash, telegram.Options{
+
+	opts := telegram.Options{
 		SessionStorage: &telegram.FileSessionStorage{Path: session},
-	})
+	}
+	if socksProxy := strings.TrimSpace(os.Getenv("SOCKS5_PROXY")); socksProxy != "" {
+		dialer, err := proxy.SOCKS5("tcp", socksProxy, nil, proxy.Direct)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: invalid SOCKS5_PROXY: %v\n", err)
+			os.Exit(2)
+		}
+		opts.Resolver = dcs.Plain(dcs.PlainOptions{
+			Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.Dial(network, addr)
+			},
+		})
+	}
+
+	client := telegram.NewClient(apiID, apiHash, opts)
+
 	if err := client.Run(ctx, func(ctx context.Context) error {
 		status, err := client.Auth().Status(ctx)
 		if err != nil {
@@ -613,7 +632,9 @@ func fetchDocument(ctx context.Context, api *tg.Client, dl *downloader.Downloade
 	}
 	if !reused {
 		fmt.Printf("[network fetch] document=%d resource=document expected_size=%d part_size=%d\n", doc.ID, doc.Size, downloadPartSize(doc.Size))
-		data, err = download(ctx, api, dl, doc, "", doc.Size, maxBytes)
+		data, err = retryOnTimeout(ctx, fmt.Sprintf("document %d", doc.ID), func() ([]byte, error) {
+            return download(ctx, api, dl, doc, "", doc.Size, maxBytes)
+        })
 		if err != nil {
 			return documentManifest{}, fmt.Errorf("download document %d: %w", doc.ID, err)
 		}
@@ -697,7 +718,9 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 			if err == nil && !reused {
 				downloadAttempted = true
 				fmt.Printf("[network fetch] document=%d resource=photo-thumb type=%s expected_size=%d part_size=%d\n", doc.ID, thumbType, expectedSize, downloadPartSize(expectedSize))
-				data, err = download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
+				data, err = retryOnTimeout(ctx, fmt.Sprintf("photo-thumb %d (%s)", doc.ID, thumbType), func() ([]byte, error) {
+                    return download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
+                })
 			}
 		case *tg.PhotoSizeProgressive:
 			if len(value.Sizes) == 0 {
@@ -713,7 +736,9 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 			if err == nil && !reused {
 				downloadAttempted = true
 				fmt.Printf("[network fetch] document=%d resource=photo-thumb-progressive type=%s expected_size=%d part_size=%d\n", doc.ID, thumbType, expectedSize, downloadPartSize(expectedSize))
-				data, err = download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
+				data, err = retryOnTimeout(ctx, fmt.Sprintf("progressive-thumb %d (%s)", doc.ID, thumbType), func() ([]byte, error) {
+                    return download(ctx, api, dl, doc, thumbType, expectedSize, maxBytes)
+                })
 			}
 		default:
 			continue
@@ -755,7 +780,9 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 		if err == nil && !reused {
 			downloadAttempted = true
 			fmt.Printf("[network fetch] document=%d resource=video-thumb type=%s expected_size=%d part_size=%d\n", doc.ID, value.Type, value.Size, downloadPartSize(int64(value.Size)))
-			data, err = download(ctx, api, dl, doc, value.Type, int64(value.Size), maxBytes)
+			data, err = retryOnTimeout(ctx, fmt.Sprintf("video-thumb %d (%s)", doc.ID, value.Type), func() ([]byte, error) {
+                return download(ctx, api, dl, doc, value.Type, int64(value.Size), maxBytes)
+            })
 		}
 		if err != nil {
 			if downloadAttempted && missingThumbAllowed(allowedMissingThumbs, doc.ID, "video", value.Type) {
@@ -784,6 +811,41 @@ func fetchThumbs(ctx context.Context, api *tg.Client, dl *downloader.Downloader,
 		return missing[i].Type < missing[j].Type
 	})
 	return artifacts, missing, nil
+}
+
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "-503") ||
+		strings.Contains(msg, "Timeout") ||
+		strings.Contains(msg, "FLOOD_WAIT") ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "connection reset by peer")
+}
+
+func retryOnTimeout(ctx context.Context, desc string, op func() ([]byte, error)) ([]byte, error) {
+	const maxRetries = 6
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		data, err := op()
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			return nil, err
+		}
+		backoff := time.Duration(attempt*2) * time.Second
+		fmt.Printf("[retry %d/%d] %s: %v (waiting %v)\n", attempt, maxRetries, desc, err, backoff)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return nil, fmt.Errorf("failed after %d attempts: %w", maxRetries, lastErr)
 }
 
 func download(ctx context.Context, api *tg.Client, dl *downloader.Downloader, doc *tg.Document, thumbType string, expectedSize, maxBytes int64) ([]byte, error) {

--- a/cmd/giftfetch/main_test.go
+++ b/cmd/giftfetch/main_test.go
@@ -112,6 +112,57 @@ func TestParseAllowedMissingThumbs(t *testing.T) {
 	}
 }
 
+func TestParseSOCKS5Proxy(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		address  string
+		authUser string
+		authPass string
+	}{
+		{name: "bare host port", raw: "127.0.0.1:1080", address: "127.0.0.1:1080"},
+		{name: "url host port", raw: "socks5://proxy.example:1080", address: "proxy.example:1080"},
+		{name: "url trailing slash", raw: "socks5://proxy.example:1080/", address: "proxy.example:1080"},
+		{name: "url ipv6", raw: "socks5://[2001:db8::1]:1080", address: "[2001:db8::1]:1080"},
+		{name: "url auth", raw: "socks5://user:pass@proxy.example:1080", address: "proxy.example:1080", authUser: "user", authPass: "pass"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseSOCKS5Proxy(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Address != test.address {
+				t.Fatalf("address = %q, want %q", got.Address, test.address)
+			}
+			if test.authUser == "" {
+				if got.Auth != nil {
+					t.Fatalf("auth = %+v, want nil", got.Auth)
+				}
+				return
+			}
+			if got.Auth == nil || got.Auth.User != test.authUser || got.Auth.Password != test.authPass {
+				t.Fatalf("auth = %+v, want %q/%q", got.Auth, test.authUser, test.authPass)
+			}
+		})
+	}
+
+	for _, raw := range []string{
+		"",
+		"127.0.0.1",
+		"socks5://127.0.0.1",
+		"http://127.0.0.1:1080",
+		"socks5://127.0.0.1:1080/path",
+		"socks5://127.0.0.1:1080?debug=true",
+	} {
+		t.Run("invalid "+raw, func(t *testing.T) {
+			if _, err := parseSOCKS5Proxy(raw); err == nil {
+				t.Fatalf("parseSOCKS5Proxy(%q) succeeded", raw)
+			}
+		})
+	}
+}
+
 func TestExistingArtifact(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "resource.bin"), []byte("gift"), 0o644); err != nil {


### PR DESCRIPTION
Telegram net errors used to crash the binary, new error handlers add timeout. 

Optional socks5:// proxy support is added for countries with banned api.telegram.org