### PR TITLE
docker deployment

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,54 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=sha,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+
+RUN apk add --no-cache git ca-certificates tzdata
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o bin/telesrv ./cmd/telesrv && \
+    if [ -d "./cmd/telesrv-admin" ]; then \
+      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o bin/telesrv-admin ./cmd/telesrv-admin; \
+    fi && \
+    if [ -d "./cmd/telegramloginkeygen" ]; then \
+      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o bin/telegramloginkeygen ./cmd/telegramloginkeygen; \
+    fi
+
+FROM alpine:3.20 AS runner
+
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates tzdata openssl bash ffmpeg
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/bin/ /app/bin/
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
+RUN chmod +x /app/docker-entrypoint.sh && \
+    mkdir -p /app/data /app/storage
+
+EXPOSE 2398 2400 2401 6060 8088 12399/udp 12400/udp 12500-12999/udp
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/bin/telesrv"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,99 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: gramsrv-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-telesrv}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-telesrv}
+      POSTGRES_DB: ${POSTGRES_DB:-telesrv}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-telesrv} -d ${POSTGRES_DB:-telesrv}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - gramsrv-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: gramsrv-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--port", "6399"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6399", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - gramsrv-net
+
+  telesrv:
+    image: ghcr.io/iamxvbaba/gramsrv:latest
+    container_name: gramsrv-server
+    restart: unless-stopped
+    pull_policy: always
+    env_file:
+      - .env
+    environment:
+      - TELESRV_POSTGRES_DSN=postgres://${POSTGRES_USER:-telesrv}:${POSTGRES_PASSWORD:-telesrv}@postgres:5432/${POSTGRES_DB:-telesrv}?sslmode=disable
+      - TELESRV_REDIS_ADDR=redis:6399
+      - TELESRV_DATA_DIR=/app/data
+      - TELESRV_RSA_KEY=/app/data/server_rsa.pem
+      - TELESRV_LISTEN=0.0.0.0:2398
+      - TELESRV_PUBLIC_LINK_WEB_ADDR=0.0.0.0:2401
+      - TELESRV_LIVESTREAM_RTMP_ADDR=0.0.0.0:2400
+    ports:
+      - "2398:2398"                    # MTProto TCP / WebSocket
+      - "2400:2400"                    # RTMP Ingest (OBS)
+      - "2401:2401"                    # Public Web / OIDC Login
+      - "12399:12399/udp"              # SFU / WebRTC Media
+      - "12400:12400/udp"              # TURN control
+      - "12500-12999:12500-12999/udp"  # Dynamic TURN Relay allocation
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - gramsrv-net
+
+  telesrv-admin:
+    image: ghcr.io/iamxvbaba/gramsrv:latest
+    container_name: gramsrv-admin
+    restart: unless-stopped
+    pull_policy: always
+    entrypoint: ["/app/bin/telesrv-admin"]
+    env_file:
+      - .env
+    environment:
+      - TELESRV_POSTGRES_DSN=postgres://${POSTGRES_USER:-telesrv}:${POSTGRES_PASSWORD:-telesrv}@postgres:5432/${POSTGRES_DB:-telesrv}?sslmode=disable
+      - TELESRV_REDIS_ADDR=redis:6399
+      - TELESRV_ADMIN_UI_ADDR=0.0.0.0:2600
+    ports:
+      - "2600:2600"
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      telesrv:
+        condition: service_started
+    networks:
+      - gramsrv-net
+
+networks:
+  gramsrv-net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+DATA_DIR="${TELESRV_DATA_DIR:-/app/data}"
+RSA_KEY="${TELESRV_RSA_KEY:-${DATA_DIR}/server_rsa.pem}"
+RSA_PUB="${RSA_KEY%.*}.pub"
+LOGIN_DIR="${DATA_DIR}/telegram-login"
+
+mkdir -p "$DATA_DIR"
+
+# 1. Background watcher: Generate server_rsa.pub once server creates server_rsa.pem
+(
+    until [ -f "$RSA_KEY" ]; do
+        sleep 0.5
+    done
+
+    if [ ! -f "$RSA_PUB" ]; then
+        echo "[Entrypoint Watcher] Detected $RSA_KEY, generating $RSA_PUB..."
+        openssl rsa -in "$RSA_KEY" -pubout -out "$RSA_PUB" 2>/dev/null || openssl pkey -in "$RSA_KEY" -pubout -out "$RSA_PUB"
+        chmod 644 "$RSA_PUB"
+        echo "[Entrypoint Watcher] Public key generated at $RSA_PUB"
+    fi
+) &
+
+# 2. Telegram Login / OIDC Keygen Initialization
+if [ ! -f "${LOGIN_DIR}/signing-keys.json" ]; then
+    if [ -x "/app/bin/telegramloginkeygen" ]; then
+        echo "[Entrypoint] Initializing Telegram Login keys in $LOGIN_DIR..."
+        mkdir -p "$LOGIN_DIR"
+        /app/bin/telegramloginkeygen -mode=init -dir="$LOGIN_DIR" || true
+        chmod 0700 "$LOGIN_DIR" 2>/dev/null || true
+        chmod 0600 "$LOGIN_DIR"/* 2>/dev/null || true
+    fi
+fi
+
+echo "[Entrypoint] Starting application: $@"
+exec "$@"


### PR DESCRIPTION
`docker-compose.yml` pulls `ghcr.io/iamxvbaba/gramsrv:latest` release, which is triggered by `v*` tag.

Production docker deployment does not interfere with binary, but postres and redis are deployed from project root, so existing database in `deploy/docker-compose.yml` folder must be stopped.

Developers would continue to use legacy `go build` method, while users can choose easier docker deployment with stable updates by `docker compose pull`