### PR TITLE
fix: keep session-auth user separate from async presence push in test double

### DIFF
--- a/internal/rpc/router_auth_cache_test.go
+++ b/internal/rpc/router_auth_cache_test.go
@@ -40,6 +40,24 @@ func (s *authBindingCaptureSessions) PushToUserExceptAuthKeySession(_ context.Co
 	return 1, nil
 }
 
+// PushToUserTransientExceptAuthKeySession must also be overridden: the presence
+// announcer (announceSessionOnline -> pushSessionOnlineAsync) delivers status
+// pushes through this transient variant on a background goroutine. Without
+// this override the embedded captureSessions.PushToUserTransientExceptAuthKeySession
+// promotion calls its own PushToUserExceptAuthKeySession (not this type's
+// override, since Go embedding has no virtual dispatch), which writes userID
+// as a side effect. That async write can land after revokeAuthKeySessions has
+// already cleared the session, flakily resurrecting a revoked identity.
+func (s *authBindingCaptureSessions) PushToUserTransientExceptAuthKeySession(_ context.Context, userID int64, _ [8]byte, _ int64, t proto.MessageType, msg tg.UpdatesClass, _ time.Duration) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messageType = t
+	s.message = msg
+	s.userMessage = msg
+	s.pushUserIDs = append(s.pushUserIDs, userID)
+	return 1, nil
+}
+
 func TestDispatchPromotesNegativeSessionCacheFromPositiveAuthCache(t *testing.T) {
 	authKeyID := [8]byte{0x91, 0x91, 0x91, 0x91, 0x91, 0x91, 0x91, 0x91}
 	const (


### PR DESCRIPTION
Fixes a real flakiness in `TestDispatchUsesCachedTempAuthKeyUserUntilWriteSideInvalidation` (`internal/rpc/router_auth_cache_test.go`), reproduced roughly 1 run in 15-20 under repeated `go test -count=1`.

## Root cause

The test double `authBindingCaptureSessions` overrides `PushToUserExceptAuthKeySession` to keep session-auth state (which user this session is bound to) separate from the target of an asynchronous presence push, per its own doc comment. It did **not** override `PushToUserTransientExceptAuthKeySession` — the variant actually used by the background `announceSessionOnline -> pushUserMessageTransient` path.

Since Go embedding has no virtual dispatch, the embedded `captureSessions.PushToUserTransientExceptAuthKeySession` fell through to its *own* `PushToUserExceptAuthKeySession`, which mutates `userID` as a side effect. That background write could land after `revokeAuthKeySessions` had already cleared the session, flakily resurrecting a revoked identity in the test assertion — a test-double bug, not a production issue (the router logic itself correctly rejects the post-revocation RPC with `AUTH_KEY_UNREGISTERED` every time; only the test's own state snapshot was racy).

## Fix

Add the missing override, mirroring the existing one.

## Testing

- `go build ./...`
- `go test ./internal/rpc/... -run TestDispatchUsesCachedTempAuthKeyUserUntilWriteSideInvalidation -count=60` — 0 failures after the fix (previously reproduced within ~15-20 runs)
- `go test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)