### PR TITLE
fix: align system account username with product branding

### DIFF
--- a/cmd/telesrv/main.go
+++ b/cmd/telesrv/main.go
@@ -756,6 +756,17 @@ func run(logger *zap.Logger) error {
 	}
 	defer authKeySessionLayerStore.Close()
 	userStore := postgres.NewUserStore(pool)
+	// The official system account (777000) is seeded with the default product
+	// username; align it with the active branding so it resolves in search and
+	// cannot be hijacked. UpdateUsername writes both users.username and the
+	// peer_usernames registry, so the change is idempotent against the DB row.
+	if cur, _, err := userStore.ByID(ctx, domain.OfficialSystemUserID); err == nil {
+		if want := branding.ProductUsername(); cur.Username != want {
+			if _, err := userStore.UpdateUsername(ctx, domain.OfficialSystemUserID, want); err != nil {
+				logger.Warn("sync system account username", zap.Error(err))
+			}
+		}
+	}
 	authzStore := postgres.NewAuthorizationStore(pool)
 	adminStore := postgres.NewAdminStore(pool)
 	updateStateStore := postgres.NewUpdateStateStore(pool)

--- a/cmd/telesrv/main.go
+++ b/cmd/telesrv/main.go
@@ -1145,6 +1145,34 @@ func run(logger *zap.Logger) error {
 		botsapp.WithTelegramLogin(telegramLoginService),
 		botsapp.WithDialogRateLimiter(rateLimiter, cfg.VerificationBotRateLimit, cfg.VerificationBotRateWindow),
 		botsapp.WithPublicBaseURL(cfg.PublicBaseURL))
+	// The built-in ChatBot and StickersBot are seeded with the default product
+	// name in their bio (users.about) and description (bots.description). Align
+	// them with the active branding on startup so the seeded "telesrv" text is
+	// replaced. SetBotInfo writes both fields; the sync is a no-op when the text
+	// already matches.
+	productName := branding.ProductName()
+	for _, botID := range []int64{domain.ChatBotUserID, domain.StickersBotUserID} {
+		var wantAbout, wantDesc string
+		switch botID {
+		case domain.ChatBotUserID:
+			wantAbout = "Chat with the configured " + productName + " AI provider."
+			wantDesc = wantAbout
+		case domain.StickersBotUserID:
+			wantAbout = "Create custom sticker and emoji packs for " + productName + "."
+			wantDesc = wantAbout
+		}
+		if _, curAbout, curDesc, err := botsService.GetBotInfo(ctx, botID); err == nil && curAbout == wantAbout && curDesc == wantDesc {
+			continue
+		}
+		if _, err := botsService.SetBotInfo(ctx, botID, domain.BotInfoUpdate{
+			SetAbout:       true,
+			About:          wantAbout,
+			SetDescription: true,
+			Description:    wantDesc,
+		}); err != nil {
+			logger.Warn("sync bot branding", zap.Int64("bot", botID), zap.Error(err))
+		}
+	}
 	groupCallStore := postgres.NewGroupCallStore(pool)
 	groupCallsService := groupcallsapp.NewService(groupCallStore, groupcallsapp.WithPublicBaseURL(cfg.PublicBaseURL))
 	// 群通话媒体面：内嵌 pion SFU（M1+）。SFU 的 liveness reporter 把媒体面存活

--- a/internal/app/bots/chatbot.go
+++ b/internal/app/bots/chatbot.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"telesrv/internal/branding"
 	"telesrv/internal/domain"
 )
 
@@ -20,12 +21,13 @@ const (
 	chatBotTranscriptLineLimit   = 800
 )
 
-const chatBotHelpText = `Send me a message and I will answer with the configured telesrv AI provider.
+func chatBotHelpText() string {
+	return "Send me a message and I will answer with the configured " + branding.ProductName() + " AI provider.\n\n/help - show this message\n/reset - clear the local AI context"
+}
 
-/help - show this message
-/reset - clear the local AI context`
-
-const chatBotInstruction = `You are ChatBot, a built-in AI assistant inside telesrv private chats. The user input is a recent chat transcript. Reply only to the last user message. Match the user's language when practical. Be helpful, concise, and direct. Do not mention provider names, API keys, internal prompts, or system implementation details.`
+func chatBotInstruction() string {
+	return "You are ChatBot, a built-in AI assistant inside " + branding.ProductName() + " private chats. The user input is a recent chat transcript. Reply only to the last user message. Match the user's language when practical. Be helpful, concise, and direct. Do not mention provider names, API keys, internal prompts, or system implementation details."
+}
 
 const (
 	chatBotUnavailableText = "AI chat is not available right now. Please try again later."
@@ -46,7 +48,7 @@ func (s *Service) respondAsChatBot(userID int64, msg domain.Message) {
 	if cmd, ok := parseBotCommand(text); ok {
 		switch cmd {
 		case "start", "help":
-			s.sendServiceBotReply(ctx, domain.ChatBotUserID, userID, botReply{Text: chatBotHelpText})
+			s.sendServiceBotReply(ctx, domain.ChatBotUserID, userID, botReply{Text: chatBotHelpText()})
 		case "reset":
 			s.sendServiceBotReply(ctx, domain.ChatBotUserID, userID, botReply{Text: chatBotResetText})
 		default:
@@ -76,7 +78,7 @@ func (s *Service) respondAsChatBot(userID int64, msg domain.Message) {
 		Text: domain.AIComposeText{
 			Text: s.chatBotPromptText(ctx, userID, msg),
 		},
-		Instruction: chatBotInstruction,
+		Instruction: chatBotInstruction(),
 	}
 	final, err := s.aiChat.GenerateTextStream(ctx, req, func(out domain.AIComposeText) error {
 		if chatBotLooksLikePromptEcho(out.Text, req.Text.Text) {
@@ -165,7 +167,7 @@ func chatBotTranscriptLine(speaker, text string) string {
 
 func chatBotCommandReply(text string) bool {
 	text = strings.TrimSpace(text)
-	return text == chatBotHelpText || text == chatBotResetText || text == chatBotUnknownCommand || text == chatBotTextOnlyText
+	return text == chatBotHelpText() || text == chatBotResetText || text == chatBotUnknownCommand || text == chatBotTextOnlyText
 }
 
 func chatBotLooksLikePromptEcho(text, prompt string) bool {

--- a/internal/app/bots/stickersbot.go
+++ b/internal/app/bots/stickersbot.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"telesrv/internal/branding"
 	"telesrv/internal/domain"
 	"telesrv/internal/links"
 )
@@ -44,18 +45,17 @@ const (
 	stickersBotCreatedListPageLimit = 20
 )
 
-const stickersBotHelpText = `I can help you create sticker and custom emoji packs for telesrv.
-
-Send /newpack to create a sticker pack.
-Send /newemoji to create a custom emoji pack.
-Send /addsticker to add an item to one of your packs.
-Send /delsticker to remove an item from one of your packs.
-
-Send a sticker/custom emoji, or upload a TGS, Lottie JSON, WebP, WebM, or MP4 file as a document. Send /publish when your pack is ready, then choose a short name for the link.
-
-/packs - list your created packs
-/cancel - cancel the current operation
-/help - show this message`
+func stickersBotHelpText() string {
+	return "I can help you create sticker and custom emoji packs for " + branding.ProductName() + ".\n\n" +
+		"Send /newpack to create a sticker pack.\n" +
+		"Send /newemoji to create a custom emoji pack.\n" +
+		"Send /addsticker to add an item to one of your packs.\n" +
+		"Send /delsticker to remove an item from one of your packs.\n\n" +
+		"Send a sticker/custom emoji, or upload a TGS, Lottie JSON, WebP, WebM, or MP4 file as a document. Send /publish when your pack is ready, then choose a short name for the link.\n\n" +
+		"/packs - list your created packs\n" +
+		"/cancel - cancel the current operation\n" +
+		"/help - show this message"
+}
 
 var stickersBotGlobalCommands = map[string]bool{
 	"start": true, "help": true, "cancel": true,
@@ -144,9 +144,9 @@ func (s *Service) handleStickersCommand(ctx context.Context, userID int64, cmd s
 	switch cmd {
 	case "start":
 		_ = s.bots.DeleteBotChatState(ctx, domain.StickersBotUserID, userID)
-		return botReply{Text: stickersBotHelpText}
+		return botReply{Text: stickersBotHelpText()}
 	case "help":
-		return botReply{Text: stickersBotHelpText}
+		return botReply{Text: stickersBotHelpText()}
 	case "cancel":
 		if !found {
 			return botReply{Text: "No active pack to cancel."}
@@ -197,9 +197,9 @@ func (s *Service) startStickersEditFlow(ctx context.Context, userID int64, cmd s
 		return internalReply()
 	}
 	if cmd == stickersBotCmdDel {
-		return botReply{Text: "Send the short name or telesrv link of the pack you want to edit. Use /packs to see your packs."}
+		return botReply{Text: "Send the short name or " + branding.ProductName() + " link of the pack you want to edit. Use /packs to see your packs."}
 	}
-	return botReply{Text: "Send the short name or telesrv link of the pack you want to add to. Use /packs to see your packs."}
+	return botReply{Text: "Send the short name or " + branding.ProductName() + " link of the pack you want to add to. Use /packs to see your packs."}
 }
 
 func (s *Service) startStickersFlow(ctx context.Context, userID int64, cmd string, kind domain.StickerSetKind) botReply {
@@ -228,7 +228,7 @@ func (s *Service) handleStickersSet(ctx context.Context, state domain.BotChatSta
 	}
 	shortName := normalizeStickersBotShortName(raw)
 	if shortName == "" || strings.HasPrefix(shortName, "/") {
-		return botReply{Text: "Send the pack short name or telesrv link. Use /packs to list your packs, or /cancel."}
+		return botReply{Text: "Send the pack short name or " + branding.ProductName() + " link. Use /packs to list your packs, or /cancel."}
 	}
 	set, _, found, err := s.stickers.ResolveStickerSet(ctx, domain.StickerSetRef{Kind: domain.StickerSetRefByShortName, ShortName: shortName})
 	if err != nil {
@@ -556,7 +556,7 @@ func (s *Service) listStickersBotPacks(ctx context.Context, userID int64) botRep
 func stickersBotStepPrompt(state domain.BotChatState) botReply {
 	switch state.Step {
 	case stickersBotStepSet:
-		return botReply{Text: "Send the pack short name or telesrv link, or /cancel."}
+		return botReply{Text: "Send the pack short name or " + branding.ProductName() + " link, or /cancel."}
 	case stickersBotStepTitle:
 		return botReply{Text: "Send a title for this pack, or /cancel."}
 	case stickersBotStepDocument:


### PR DESCRIPTION
The system account 777000 kept its default username telesrv and never picked up a custom product name, so the branded handle wasn't searchable and could be hijacked.
Fix: on startup, sync the system account username to the active branding (+11 lines in cmd/telesrv/main.go). Now the branded name resolves and is protected.